### PR TITLE
PD Turret Buff

### DIFF
--- a/Content.Server/NPC/NPCBlackboard.cs
+++ b/Content.Server/NPC/NPCBlackboard.cs
@@ -31,7 +31,7 @@ public sealed partial class NPCBlackboard : IEnumerable<KeyValuePair<string, obj
         {"MovementRangeClose", 0.2f},
         {"MovementRange", 1.5f},
         {"RangedRange", 10f},
-        {"RangedRangeLR", 20f},
+        {"RangedRangeLR", 60f},
         {"RotateSpeed", float.MaxValue},
         {"VisionRadius", 10f},
         {"AggroVisionRadius", 10f},

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -658,19 +658,6 @@
     radius: 3.5
     color: orange
     energy: 0.5
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 - type: entity
   id: BulletWeakRocket
@@ -693,19 +680,6 @@
     radius: 3.5
     color: orange
     energy: 0.5
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 - type: entity
   id: BulletGrenadeBaton
@@ -743,19 +717,6 @@
     totalIntensity: 150 # a ~2 tile radius
     intensitySlope: 5
     maxIntensity: 10
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 60
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 - type: entity
   id: BulletGrenadeFlash
@@ -774,19 +735,6 @@
   - type: ActiveTimerTrigger
     timeRemaining: 0.3
   - type: DeleteOnTrigger
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 60
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 # This is supposed to spawn shrapnel and stuff so uhh... TODO?
 - type: entity
@@ -805,19 +753,6 @@
     totalIntensity: 175 # about a ~6 tile radius
     intensitySlope: 1
     maxIntensity: 10
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 60
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 - type: entity
   id: BulletGrenadeEMP
@@ -839,19 +774,6 @@
     radius: 3.5
     color: blue
     energy: 0.5
-  - type: NpcFactionMember # mono
-    factions:
-    - PDTarget
-  - type: Destructible # mono
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 60
-      behaviors:
-      - !type:DoActsBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
 
 - type: entity
   id: BulletCap

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
@@ -108,7 +108,7 @@
   parent: BaseWeaponTurretPD
   id: WeaponTurretPDK30
   name: K-30 point defense turret
-  description: A basic .25 caseless PD turret. Produces ammo from internal ammo fabricators, automatically targets meteors. Low-range though.
+  description: A basic .25 caseless PD turret. Produces ammo from internal ammo fabricators, automatically targets meteors.
   suffix: PointDefence
   components:
   - type: NpcFactionMember

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
@@ -65,7 +65,7 @@
       maxAngle: 4
       angleIncrease: 2
       angleDecay: 8
-      fireRate: 16
+      fireRate: 20
       selectedMode: FullAuto
       availableModes:
         - FullAuto
@@ -78,9 +78,13 @@
         task: TurretCompoundPD
       blackboard:
         RotateSpeed: !type:Single
-          6.282
+          12.564
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/_Mono/Weapons/Misc/pdtarget.ogg
+        VisionRadius: !type:Single
+          60.0
+        AggroVisionRadius: !type:Single
+          60.0
     - type: MouseRotator
       angleTolerance: 5
       rotationSpeed: 360


### PR DESCRIPTION
## About the PR
- Buffed PD turrets.
- Increased their range from 10 to 60.
- Reverted some projectile changes from a prior PD update.
- Updated description to no longer say they are close range.

## Why / Balance
Meteor update, just a week away!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Ark
- tweak: Buffed PD turrets and gave them longer range. Meteor update, just a week away!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NPCs now engage at longer ranged distances for improved combat interactions.
  - Point-defense turrets have enhanced performance with a quicker firing rate, faster rotation, and expanded detection ranges.
  - A new, modular turret option is now available for construction.

- **Refactor**
  - Projectile behavior has been streamlined by removing faction affiliation and destructibility interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->