### PR TITLE
20mm caseless turret

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_20mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_20mm.yml
@@ -1,0 +1,30 @@
+- type: entity
+  id: BaseCartridgeCaselessAutocannon
+  name: cartridge (20x165mm PD caseless)
+  parent: [ BaseCartridge, BaseRestrictedContraband ]
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+      - Cartridge
+      - CartridgeCaselessAutocannon
+  - type: CartridgeAmmo
+    deleteOnSpawn: true
+  - type: Sprite
+    noRot: false
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
+    layers:
+    - state: base
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+  - type: StaticPrice
+    price: 10
+
+- type: entity
+  id: CartridgeCaselessAutocannon
+  name: cartridge (20x165mm PD caseless)
+  parent: BaseCartridgeCaselessRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletCaselessAutocannon

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_20mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_20mm.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: BulletCaselessAutocannon
+  name: bullet (20x165mm PD caseless)
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 120

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/point_defense.yml
@@ -10,6 +10,8 @@
     - type: Clickable
     - type: InteractionOutline
     - type: Actions
+    - type: Anchorable
+      delay: 10
     - type: Fixtures
       fixtures:
         fix1:
@@ -82,9 +84,9 @@
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/_Mono/Weapons/Misc/pdtarget.ogg
         VisionRadius: !type:Single
-          60.0
+          35.0
         AggroVisionRadius: !type:Single
-          60.0
+          35.0
     - type: MouseRotator
       angleTolerance: 5
       rotationSpeed: 360
@@ -104,6 +106,8 @@
       autoRecharge: true
       autoRechargeRate: 100
 
+# K-30 (.25 caseless)
+
 - type: entity
   parent: BaseWeaponTurretPD
   id: WeaponTurretPDK30
@@ -117,7 +121,7 @@
 
 - type: entity
   parent: BaseFlatpack
-  id: PDTurretFlatpack
+  id: PDTurretFlatpackK30
   name: K-30 PD turret flatpack
   description: A flatpack used for constructing a K-30 point defence turret. Requires no external connections to function.
   components:
@@ -125,3 +129,43 @@
     entity: WeaponTurretPDK30
   - type: StaticPrice
     price: 250
+
+# ML-550 (20mm caseless)
+
+- type: entity
+  parent: BaseWeaponTurretPD
+  id: WeaponTurretPDML550
+  name: ML-550 point defense turret
+  description: A heavy point defense turret firing 20x165mm PD. Produces ammo from internal ammo fabricators, automatically targets meteors.
+  suffix: PointDefence
+  components:
+  - type: NpcFactionMember
+    factions:
+    - PointDefence
+  - type: ProjectileBatteryAmmoProvider
+    proto: CartridgeCaselessAutocannon
+    fireCost: 500
+  - type: Gun
+    minAngle: 1
+    maxAngle: 2
+    angleIncrease: 1
+    angleDecay: 4
+    fireRate: 4
+    selectedMode: FullAuto
+    availableModes:
+      - FullAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/mateba.ogg
+    soundEmpty:
+      path: /Audio/Weapons/Guns/EmptyAlarm/lmg_empty_alarm.ogg
+
+- type: entity
+  parent: BaseFlatpack
+  id: PDTurretFlatpackML550
+  name: ML-550 PD turret flatpack
+  description: A flatpack used for constructing a ML-550 point defence turret. Requires no external connections to function.
+  components:
+  - type: Flatpack
+    entity: WeaponTurretPDML550
+  - type: StaticPrice
+    price: 1000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes the pd turret range less stupid OP
adds secondary PD turret variant in 20mm

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added 20mm caseless PD turret variant
- tweak: PD turret range changed from 60 to 35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new caseless ammunition types with enhanced damage profiles.
  - Added a novel bullet type designed for piercing impact.
  - Expanded point defense capabilities with two new turret variants offering improved targeting and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->