### PR TITLE
Revert "[Bounty] Ghost Verbs (#1368)" - MRPify

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -634,13 +634,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         var clients = GetDeadChatClients();
         var playerName = Name(source);
         string wrappedMessage;
-
-        var speech = GetSpeechVerb(source, message); // Goobstation - Dead chat verbs
-
         if (_adminManager.IsAdmin(player))
         {
             wrappedMessage = Loc.GetString("chat-manager-send-admin-dead-chat-wrap-message",
-                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))), // Goobstation - Dead chat verbs
                 ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")),
                 ("userName", player.Channel.UserName),
                 ("message", FormattedMessage.EscapeText(message)));
@@ -649,7 +645,6 @@ public sealed partial class ChatSystem : SharedChatSystem
         else
         {
             wrappedMessage = Loc.GetString("chat-manager-send-dead-chat-wrap-message",
-                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))), // Goobstation - Dead chat verbs
                 ("deadChannelName", Loc.GetString("chat-manager-dead-channel-name")),
                 ("playerName", (playerName)),
                 ("message", FormattedMessage.EscapeText(message)));

--- a/Resources/Locale/en-US/_Goobstation/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/_Goobstation/chat/managers/chat-manager.ftl
@@ -4,17 +4,6 @@ chat-speech-verb-name-gondola = Gondola
 chat-speech-verb-gondola-1 = stares
 chat-speech-verb-gondola-2 = breathes
 
-chat-speech-verb-name-dead = Dead
-chat-speech-verb-dead-1 = salts
-chat-speech-verb-dead-2 = malds
-chat-speech-verb-dead-3 = copes
-chat-speech-verb-dead-4 = seethes
-chat-speech-verb-dead-5 = laments
-chat-speech-verb-dead-6 = whines
-chat-speech-verb-dead-7 = moans
-chat-speech-verb-dead-8 = cries
-chat-speech-verb-dead-9 = wails
-
 chat-speech-verb-VoiceModulator-name = Voice Modulator
 chat-speech-verb-VoiceModulator-1 = modulates
 chat-speech-verb-VoiceModulator-2 = buzzes

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -22,11 +22,11 @@ chat-manager-server-wrap-message = [bold]{$message}[/bold]
 chat-manager-sender-announcement = Central Command
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} Announcement:[/font][font size=12]
                                                 {$message}[/bold][/font]
-chat-manager-entity-say-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}: [font={$fontType} size={$fontSize}]"[BubbleContent]{$message}[/BubbleContent]"[/font]
-chat-manager-entity-say-bold-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}: [font={$fontType} size={$fontSize}]"[BubbleContent][bold]{$message}[/bold][/BubbleContent]"[/font]
+chat-manager-entity-say-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent]{$message}[/BubbleContent]"[/font]
+chat-manager-entity-say-bold-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent][bold]{$message}[/bold][/BubbleContent]"[/font]
 
-chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] whispers: "[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]
-chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][BubbleHeader]Someone[/BubbleHeader] whispers: "[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]
+chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] whispers,"[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]
+chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][BubbleHeader]Someone[/BubbleHeader] whispers, "[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]
 
 # THE() is not used here because the entity and its name can technically be disconnected if a nameOverride is passed...
 chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
@@ -38,8 +38,8 @@ chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$mess
 chat-manager-send-ooc-wrap-message = OOC: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-ooc-patron-wrap-message = OOC: [bold][color={$patronColor}]{$playerName}[/color]:[/bold] {$message}
 
-chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold][BubbleHeader]{$playerName}[/BubbleHeader][/bold] {$verb}: "[BubbleContent]{$message}[/BubbleContent]"
-chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]([BubbleHeader]{$userName}[/BubbleHeader])[/bold] {$verb}: "[BubbleContent]{$message}[/BubbleContent]"
+chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold][BubbleHeader]{$playerName}[/BubbleHeader]:[/bold] [BubbleContent]{$message}[/BubbleContent]
+chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]([BubbleHeader]{$userName}[/BubbleHeader]):[/bold] [BubbleContent]{$message}[/BubbleContent]
 chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-admin-announcement-wrap-message = [bold]{$adminChannelName}: {$message}[/bold]
 

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -63,8 +63,6 @@
   - type: Tag
     tags:
     - BypassInteractionRangeChecks
-  - type: Speech #Goobstation - Dead chat verbs
-    speechVerb: Dead
   - type: GhostColor
 
 # proto for player ghosts specifically

--- a/Resources/Prototypes/_Goobstation/Voice/speech_verbs.yml
+++ b/Resources/Prototypes/_Goobstation/Voice/speech_verbs.yml
@@ -24,20 +24,6 @@
     path: /Audio/Machines/beep.ogg
 
 - type: speechVerb
-  id: Dead
-  name: chat-speech-verb-name-dead
-  speechVerbStrings:
-  - chat-speech-verb-dead-1
-  - chat-speech-verb-dead-2
-  - chat-speech-verb-dead-3
-  - chat-speech-verb-dead-4
-  - chat-speech-verb-dead-5
-  - chat-speech-verb-dead-6
-  - chat-speech-verb-dead-7
-  - chat-speech-verb-dead-8
-  - chat-speech-verb-dead-9
-
-- type: speechVerb
   id: VoiceModulator
   name: chat-speech-verb-VoiceModulator-name
   speechVerbStrings:


### PR DESCRIPTION
## About the PR
This reverts commit 3a76598d

## Why / Balance
No more malding in dead chat.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Ark
- tweak: No more malding in dead chat. MRPify.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new voice modulator speech options for a more varied chat experience.
- **Style**
	- Adjusted punctuation in chat messages for clearer, more readable displays.
- **Refactor**
	- Simplified dead chat messaging by removing redundant text elements for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->