### PR TITLE
fix honkops minpop

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -195,6 +195,8 @@
   parent: BaseNukeopsRule
   id: Honkops
   components:
+  - type: GameRule # mono - dumbasses
+    minPlayers: 20
   - type: RandomMetadata # this generates the random operation name cuz it's cool.
     nameSegments:
     - operationPrefixHonkops


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Honkops has minimum pop now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gameplay balance with updated player thresholds:
		- Honkops mode now requires at least 20 players.
		- Calm roles (Traitor, Ling, Ops, Revs) are activated with a minimum of 30 players.
		- Blob modes have been adjusted to require 15 and 20 players respectively, refining event triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->